### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/govee-h5075-prom-exporter-arm64v8.yaml
+++ b/.github/workflows/govee-h5075-prom-exporter-arm64v8.yaml
@@ -1,4 +1,6 @@
 name: govee-h5075-prom-exporter-arm64v8
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/RoggerFabri/govee-h5075-prom-exporter/security/code-scanning/1](https://github.com/RoggerFabri/govee-h5075-prom-exporter/security/code-scanning/1)

To fix the issue, a `permissions:` block should be added to restrict the GitHub Actions workflow's `GITHUB_TOKEN` to minimal privileges. The best place for this block is at the top (root) of the workflow YAML file, before the `jobs:` key. This will apply the restriction to all jobs unless overridden at the job level. The minimal recommended configuration is `contents: read`, which allows jobs to fetch code but not write to the repo or other protected resources. No additional imports or dependencies are needed. The edit involves inserting the following lines after the workflow `name:` and before `on:`:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
